### PR TITLE
Updated windows scripts

### DIFF
--- a/air-backend/installers/community/air-backend/start-backend.cmd
+++ b/air-backend/installers/community/air-backend/start-backend.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set ARCH=""
+set ARCH=
 
 docker-compose rm -f
 docker-compose up -d

--- a/air-backend/installers/community/air-backend/start.cmd
+++ b/air-backend/installers/community/air-backend/start.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set ARCH=""
+set ARCH=
 
 
 call start-backend.cmd $ARCH

--- a/air-backend/installers/community/air-backend/stop-backend.cmd
+++ b/air-backend/installers/community/air-backend/stop-backend.cmd
@@ -1,5 +1,5 @@
 @echo off
 
-set ARCH=""
+set ARCH=
 
 docker-compose down -v

--- a/air-backend/installers/community/air-backend/stop.cmd
+++ b/air-backend/installers/community/air-backend/stop.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set ARCH=""
+set ARCH=
 
 
 call stop-backend.cmd $ARCH


### PR DESCRIPTION

# Story

Updated windows scripts to use empty string instead of empty double quotes

## Changes

1. Updated start.cmd and stop.cmd
2. Updated start-backend.cmd and stop-backend.cmd

## Tests

NA
